### PR TITLE
Add microfrontend displaying jobbtreff on arbeidsplassen.no

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21054,6 +21054,7 @@
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
             "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+            "hasInstallScript": true,
             "optional": true,
             "os": [
                 "darwin"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Switch, Route } from 'react-router-dom';
 import history from './history';
 import Navigeringsmeny from './navigeringsmeny/Navigeringsmeny';
 import Modiadekoratør from './modia/Modiadekoratør';
-import { Stilling, Kandidat, Statistikk, Stillingssøk } from './microfrontends/microfrontends';
+import { Stilling, Kandidat, Statistikk, Stillingssøk, Bedriftspresentasjoner } from './microfrontends/microfrontends';
 
 const App: FunctionComponent = () => {
     const [navKontor, setNavKontor] = useState<string | null>(null);
@@ -17,6 +17,9 @@ const App: FunctionComponent = () => {
             </header>
             <main>
                 <Switch>
+                    <Route path="/bedriftspresentasjoner">
+                        <Bedriftspresentasjoner />
+                    </Route>
                     <Route path="/stillinger">
                         <Stilling navKontor={navKontor} history={history} />
                     </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Switch, Route } from 'react-router-dom';
 import history from './history';
 import Navigeringsmeny from './navigeringsmeny/Navigeringsmeny';
 import Modiadekoratør from './modia/Modiadekoratør';
-import { Stilling, Kandidat, Statistikk, Stillingssøk, Bedriftspresentasjoner } from './microfrontends/microfrontends';
+import { Stilling, Kandidat, Statistikk, Stillingssøk, Jobbtreff } from './microfrontends/microfrontends';
 
 const App: FunctionComponent = () => {
     const [navKontor, setNavKontor] = useState<string | null>(null);
@@ -17,8 +17,8 @@ const App: FunctionComponent = () => {
             </header>
             <main>
                 <Switch>
-                    <Route path="/bedriftspresentasjoner">
-                        <Bedriftspresentasjoner />
+                    <Route path="/jobbtreff">
+                        <Jobbtreff />
                     </Route>
                     <Route path="/stillinger">
                         <Stilling navKontor={navKontor} history={history} />

--- a/src/microfrontends/microfrontends.tsx
+++ b/src/microfrontends/microfrontends.tsx
@@ -45,9 +45,15 @@ const stillingssøkConfig = {
     loader: <LasterInn />,
 };
 
+const isProductionEnvironment = window.location.origin.includes('nais.adeo.no')
+
+const jobbtreffOrigin = isProductionEnvironment
+    ? 'https://rekrutteringsbistand-jobbtreff.intern.nav.no'
+    : 'https://rekrutteringsbistand-jobbtreff.dev.intern.nav.no';
+
 const jobbtreffConfig = {
     appName: 'rekrutteringsbistand-jobbtreff',
-    appBaseUrl: 'https://rekrutteringsbistand-jobbtreff.dev.intern.nav.no/rekrutteringsbistand-jobbtreff/',
+    appBaseUrl: `${jobbtreffOrigin}/rekrutteringsbistand-jobbtreff/`,
     assetManifestParser,
     loader: <LasterInn />,
 };

--- a/src/microfrontends/microfrontends.tsx
+++ b/src/microfrontends/microfrontends.tsx
@@ -45,7 +45,15 @@ const stillingssøkConfig = {
     loader: <LasterInn />,
 };
 
+const bedriftspresentasjonerConfig = {
+    appName: 'rekrutteringsbistand-bedriftspresentasjoner',
+    appBaseUrl: '/rekrutteringsbistand-bedriftspresentasjoner',
+    assetManifestParser,
+    loader: <LasterInn />,
+};
+
 export const Stilling = AsyncNavspa.importer<FellesMicrofrontendProps>(stillingConfig);
 export const Kandidat = AsyncNavspa.importer<FellesMicrofrontendProps>(kandidatConfig);
 export const Statistikk = AsyncNavspa.importer<FellesMicrofrontendProps>(statistikkConfig);
 export const Stillingssøk = AsyncNavspa.importer<FellesMicrofrontendProps>(stillingssøkConfig);
+export const Bedriftspresentasjoner = AsyncNavspa.importer(bedriftspresentasjonerConfig);

--- a/src/microfrontends/microfrontends.tsx
+++ b/src/microfrontends/microfrontends.tsx
@@ -47,7 +47,7 @@ const stillingssøkConfig = {
 
 const bedriftspresentasjonerConfig = {
     appName: 'rekrutteringsbistand-bedriftspresentasjoner',
-    appBaseUrl: '/rekrutteringsbistand-bedriftspresentasjoner',
+    appBaseUrl: 'https://rekrutteringsbistand-bedriftspresentasjoner.dev.intern.nav.no/rekrutteringsbistand-bedriftspresentasjoner/',
     assetManifestParser,
     loader: <LasterInn />,
 };

--- a/src/microfrontends/microfrontends.tsx
+++ b/src/microfrontends/microfrontends.tsx
@@ -45,9 +45,9 @@ const stillingssøkConfig = {
     loader: <LasterInn />,
 };
 
-const bedriftspresentasjonerConfig = {
-    appName: 'rekrutteringsbistand-bedriftspresentasjoner',
-    appBaseUrl: 'https://rekrutteringsbistand-bedriftspresentasjoner.dev.intern.nav.no/rekrutteringsbistand-bedriftspresentasjoner/',
+const jobbtreffConfig = {
+    appName: 'rekrutteringsbistand-jobbtreff',
+    appBaseUrl: 'https://rekrutteringsbistand-jobbtreff.dev.intern.nav.no/rekrutteringsbistand-jobbtreff/',
     assetManifestParser,
     loader: <LasterInn />,
 };
@@ -56,4 +56,4 @@ export const Stilling = AsyncNavspa.importer<FellesMicrofrontendProps>(stillingC
 export const Kandidat = AsyncNavspa.importer<FellesMicrofrontendProps>(kandidatConfig);
 export const Statistikk = AsyncNavspa.importer<FellesMicrofrontendProps>(statistikkConfig);
 export const Stillingssøk = AsyncNavspa.importer<FellesMicrofrontendProps>(stillingssøkConfig);
-export const Bedriftspresentasjoner = AsyncNavspa.importer(bedriftspresentasjonerConfig);
+export const Jobbtreff = AsyncNavspa.importer(jobbtreffConfig);

--- a/src/navigeringsmeny/Navigeringsmeny.tsx
+++ b/src/navigeringsmeny/Navigeringsmeny.tsx
@@ -29,8 +29,8 @@ const tabs: TabConfig[] = [
         path: '/kandidater/lister',
     },
     {
-        tittel: 'Bedriftspresentasjoner',
-        path: '/bedriftspresentasjoner',
+        tittel: 'Jobbtreff',
+        path: '/jobbtreff',
     },
 ];
 

--- a/src/navigeringsmeny/Navigeringsmeny.tsx
+++ b/src/navigeringsmeny/Navigeringsmeny.tsx
@@ -28,6 +28,10 @@ const tabs: TabConfig[] = [
         tittel: 'Kandidatlister',
         path: '/kandidater/lister',
     },
+    {
+        tittel: 'Bedriftspresentasjoner',
+        path: '/bedriftspresentasjoner',
+    },
 ];
 
 const Navigeringsmeny: FunctionComponent = () => {

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -15,5 +15,5 @@ module.exports = (app) => {
     setupProxy('/rekrutteringsbistand-stilling', 'http://localhost:3002');
     setupProxy('/rekrutteringsbistand-kandidat', 'http://localhost:3003');
     setupProxy('/rekrutteringsbistand-stillingssok', 'http://localhost:3004');
-    setupProxy('/rekrutteringsbistand-bedriftspresentasjoner', 'http://localhost:3005');
+    setupProxy('/rekrutteringsbistand-bedriftspresentasjoner', 'https://rekrutteringsbistand-bedriftspresentasjoner.dev.intern.nav.no/');
 };

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -15,5 +15,5 @@ module.exports = (app) => {
     setupProxy('/rekrutteringsbistand-stilling', 'http://localhost:3002');
     setupProxy('/rekrutteringsbistand-kandidat', 'http://localhost:3003');
     setupProxy('/rekrutteringsbistand-stillingssok', 'http://localhost:3004');
-    setupProxy('/rekrutteringsbistand-bedriftspresentasjoner', 'https://rekrutteringsbistand-bedriftspresentasjoner.dev.intern.nav.no/');
+    setupProxy('/rekrutteringsbistand-jobbtreff', 'https://rekrutteringsbistand-jobbtreff.dev.intern.nav.no/');
 };

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -15,4 +15,5 @@ module.exports = (app) => {
     setupProxy('/rekrutteringsbistand-stilling', 'http://localhost:3002');
     setupProxy('/rekrutteringsbistand-kandidat', 'http://localhost:3003');
     setupProxy('/rekrutteringsbistand-stillingssok', 'http://localhost:3004');
+    setupProxy('/rekrutteringsbistand-bedriftspresentasjoner', 'http://localhost:3005');
 };


### PR DESCRIPTION
A [new microfrontend app for listing jobbtreff](https://github.com/navikt/rekrutteringsbistand-jobbtreff) is created. This PR will include it in rekrutteringsbistand as a new nav menu item.

The jobbtreff microfrontend is served on the domains `dev.intern.nav.no` (dev) and `intern.nav.no` (production) and hosted in GCP. Due to this we have added some lines of code to help configure the microfrontend with the correct origins for dev/production.