### PR TITLE
Fjern proxy til finn-kandidat-api

### DIFF
--- a/deploy/nais-dev.yaml
+++ b/deploy/nais-dev.yaml
@@ -42,8 +42,6 @@ spec:
           value: https://rekrutteringsbistand-stilling-api.dev-fss-pub.nais.io
         - name: KANDIDAT_API_URL
           value: https://rekrutteringsbistand-kandidat-api.dev-fss-pub.nais.io/rekrutteringsbistand-kandidat-api/rest
-        - name: FINN_KANDIDAT_API
-          value: https://finn-kandidat-api.dev-fss-pub.nais.io/finn-kandidat-api/
         - name: SMS_API
           value: https://rekrutteringsbistand-sms.dev-fss-pub.nais.io/rekrutteringsbistand-sms/sms
         - name: FORESPORSEL_OM_DELING_AV_CV_API

--- a/deploy/nais-prod.yaml
+++ b/deploy/nais-prod.yaml
@@ -42,8 +42,6 @@ spec:
           value: https://rekrutteringsbistand-stilling-api.prod-fss-pub.nais.io
         - name: KANDIDAT_API_URL
           value: https://rekrutteringsbistand-kandidat-api.prod-fss-pub.nais.io/rekrutteringsbistand-kandidat-api/rest
-        - name: FINN_KANDIDAT_API
-          value: https://finn-kandidat-api.prod-fss-pub.nais.io/finn-kandidat-api/
         - name: SMS_API
           value: https://rekrutteringsbistand-sms.prod-fss-pub.nais.io/rekrutteringsbistand-sms/sms
         - name: FORESPORSEL_OM_DELING_AV_CV_API
@@ -52,4 +50,3 @@ spec:
           value: https://toi-synlighetsmotor.intern.nav.no
         - name: KANDIDATMATCH_API
           value: https://aimatch.intern.nav.no
-

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "server",
             "dependencies": {
                 "compression": "^1.7.4",
                 "http-proxy-middleware": "^2.0.3",
@@ -18,6 +19,7 @@
                 "@types/node": "^17.0.18",
                 "@types/node-fetch": "^2.6.1",
                 "@types/node-json-logger": "^0.0.0",
+                "@types/winston": "^2.4.4",
                 "nodemon": "^2.0.15",
                 "ts-node": "^10.5.0",
                 "typescript": "^4.5.5"
@@ -213,6 +215,16 @@
             "dependencies": {
                 "@types/mime": "^1",
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/winston": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
+            "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
+            "deprecated": "This is a stub types definition. winston provides its own type definitions, so you do not need this installed.",
+            "dev": true,
+            "dependencies": {
+                "winston": "*"
             }
         },
         "node_modules/abbrev": {
@@ -1320,9 +1332,9 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "node_modules/ms": {
@@ -2287,6 +2299,15 @@
                 "@types/node": "*"
             }
         },
+        "@types/winston": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
+            "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
+            "dev": true,
+            "requires": {
+                "winston": "*"
+            }
+        },
         "abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -3125,9 +3146,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "ms": {

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
         "@types/node": "^17.0.18",
         "@types/node-fetch": "^2.6.1",
         "@types/node-json-logger": "^0.0.0",
+        "@types/winston": "^2.4.4",
         "nodemon": "^2.0.15",
         "ts-node": "^10.5.0",
         "typescript": "^4.5.5"

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -31,7 +31,6 @@ const scopes = {
     stilling: `api://${clusterOnPrem}.arbeidsgiver.rekrutteringsbistand-stilling-api/.default`,
     kandidat: `api://${clusterOnPrem}.toi.rekrutteringsbistand-kandidat-api/.default`,
     sms: `api://${clusterOnPrem}.toi.rekrutteringsbistand-sms/.default`,
-    finnKandidatApi: `api://${clusterOnPrem}.arbeidsgiver.finn-kandidat-api/.default`,
     forespørselOmDelingAvCv: `api://${clusterOnPrem}.arbeidsgiver-inkludering.foresporsel-om-deling-av-cv-api/.default`,
     synlighetsmotor: `api://${cluster}.toi.toi-synlighetsmotor/.default`,
     kandidatmatch: `api://${cluster}.team-ai.team-ai-match/.default`,
@@ -52,10 +51,9 @@ const {
     STILLINGSSOK_PROXY_URL,
     KANDIDAT_API_URL,
     SMS_API,
-    FINN_KANDIDAT_API,
     FORESPORSEL_OM_DELING_AV_CV_API,
     SYNLIGHETSMOTOR_API,
-    KANDIDATMATCH_API
+    KANDIDATMATCH_API,
 } = process.env;
 
 const startServer = () => {
@@ -72,14 +70,13 @@ const startServer = () => {
     proxyWithAuth('/stilling-api', STILLING_API_URL, scopes.stilling);
     proxyWithAuth('/kandidat-api', KANDIDAT_API_URL, scopes.kandidat);
     proxyWithAuth('/sms-api', SMS_API, scopes.sms);
-    proxyWithAuth('/finn-kandidat-api', FINN_KANDIDAT_API, scopes.finnKandidatApi);
     proxyWithAuth(
         '/foresporsel-om-deling-av-cv-api',
         FORESPORSEL_OM_DELING_AV_CV_API,
         scopes.forespørselOmDelingAvCv
     );
     proxyWithAuth('/synlighet-api', SYNLIGHETSMOTOR_API, scopes.synlighetsmotor);
-    proxyWithAuth('/kandidatmatch-api', KANDIDATMATCH_API, scopes.kandidatmatch)
+    proxyWithAuth('/kandidatmatch-api', KANDIDATMATCH_API, scopes.kandidatmatch);
 
     app.get(
         pathsForServingApp,


### PR DESCRIPTION
Denne ble kun brukt til å hente midlertidig utilgjengelig, men dette blir slettet.