### PR TITLE
Sett opp proxy til kandidatsøk

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
               with:
                   context: .
                   push: true
-                  tags: ${{ env.docker_image }}
+                  tags: ${{ env.image }}
 
     deploy-til-dev:
         name: Deploy til dev-gcp

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
     deploy-til-dev:
         name: Deploy til dev-gcp
         needs: bygg-og-push-docker-image
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/feature-toggle-endepunkt'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/proxy-til-kandidatsok-es'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Bygg og deploy
 on: [push]
 
 env:
-    image: ghcr.io/${{ github.repository }}/rekrutteringsbistand-container:${{ github.sha }}
+    IMAGE: ghcr.io/${{ github.repository }}/rekrutteringsbistand-container:${{ github.sha }}
 
 jobs:
     bygg-og-push-docker-image:
@@ -39,7 +39,7 @@ jobs:
               with:
                   context: .
                   push: true
-                  tags: ${{ env.image }}
+                  tags: ${{ env.IMAGE }}
 
     deploy-til-dev:
         name: Deploy til dev-gcp

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Bygg og deploy
 on: [push]
 
 env:
-    IMAGE: docker.pkg.github.com/${{ github.repository }}/rekrutteringsbistand-container:${{ github.sha }}
+    IMAGE: ghcr.io/${{ github.repository }}/rekrutteringsbistand-container:${{ github.sha }}
 
 jobs:
     bygg-og-push-docker-image:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,13 +28,18 @@ jobs:
               run: cd server && npm ci
             - name: Bygg server
               run: cd server && npm run build
+            - name: Logg inn til Github
+              uses: docker/login-action@v1
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
             - name: Bygg og publiser Docker-image
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  docker build --tag ${IMAGE} .
-                  echo ${GITHUB_TOKEN} | docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} --password-stdin
-                  docker push ${IMAGE}
+              uses: docker/build-push-action@v2
+              with:
+                  context: .
+                  push: true
+                  tags: ${{ env.docker_image }}
 
     deploy-til-dev:
         name: Deploy til dev-gcp

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Bygg og deploy
 on: [push]
 
 env:
-    IMAGE: ghcr.io/${{ github.repository }}/rekrutteringsbistand-container:${{ github.sha }}
+    docker_image: ghcr.io/${{ github.repository }}/rekrutteringsbistand-container:${{ github.sha }}
 
 jobs:
     bygg-og-push-docker-image:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Bygg og deploy
 on: [push]
 
 env:
-    docker_image: ghcr.io/${{ github.repository }}/rekrutteringsbistand-container:${{ github.sha }}
+    image: ghcr.io/${{ github.repository }}/rekrutteringsbistand-container:${{ github.sha }}
 
 jobs:
     bygg-og-push-docker-image:
@@ -53,7 +53,6 @@ jobs:
                   APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
                   CLUSTER: dev-gcp
                   RESOURCE: deploy/nais-dev.yaml
-                  VAR: image=${{ env.docker_image }}
 
     deploy-to-prod:
         name: Deploy til prod-gcp
@@ -67,4 +66,3 @@ jobs:
                   APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
                   CLUSTER: prod-gcp
                   RESOURCE: deploy/nais-prod.yaml
-                  VAR: image=${{ env.docker_image }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,7 @@ jobs:
                   APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
                   CLUSTER: dev-gcp
                   RESOURCE: deploy/nais-dev.yaml
+                  VAR: image=${{ env.docker_image }}
 
     deploy-to-prod:
         name: Deploy til prod-gcp
@@ -66,3 +67,4 @@ jobs:
                   APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
                   CLUSTER: prod-gcp
                   RESOURCE: deploy/nais-prod.yaml
+                  VAR: image=${{ env.docker_image }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/node-express:14-alpine
+FROM navikt/node-express:16
 
 WORKDIR /var
 

--- a/deploy/nais-dev.yaml
+++ b/deploy/nais-dev.yaml
@@ -27,7 +27,7 @@ spec:
             enabled: true
     openSearch:
       access: read
-      instance: rekrutteringsbistand-kandidat
+      instance: kandidat
     accessPolicy:
       outbound:
         rules:

--- a/deploy/nais-dev.yaml
+++ b/deploy/nais-dev.yaml
@@ -56,5 +56,3 @@ spec:
           value: https://toi-synlighetsmotor.dev.intern.nav.no
         - name: KANDIDATMATCH_API
           value: https://aimatch.dev.intern.nav.no
-        - name: KANDIDATSOK_ES_URL
-          value: https://opensearch-toi-kandidat-nav-dev.aivencloud.com:26482

--- a/deploy/nais-dev.yaml
+++ b/deploy/nais-dev.yaml
@@ -25,6 +25,9 @@ spec:
                     - NAVident
         sidecar:
             enabled: true
+    openSearch:
+      access: read
+      instance: rekrutteringsbistand-kandidat
     accessPolicy:
       outbound:
         rules:
@@ -53,3 +56,5 @@ spec:
           value: https://toi-synlighetsmotor.dev.intern.nav.no
         - name: KANDIDATMATCH_API
           value: https://aimatch.dev.intern.nav.no
+        - name: KANDIDATSOK_ES_URL
+          value: https://opensearch-toi-kandidat-nav-dev.aivencloud.com:26482

--- a/deploy/nais-prod.yaml
+++ b/deploy/nais-prod.yaml
@@ -27,7 +27,7 @@ spec:
             enabled: true
     openSearch:
       access: read
-      instance: rekrutteringsbistand-kandidat
+      instance: kandidat
     accessPolicy:
       outbound:
         external:

--- a/deploy/nais-prod.yaml
+++ b/deploy/nais-prod.yaml
@@ -55,5 +55,3 @@ spec:
           value: https://toi-synlighetsmotor.intern.nav.no
         - name: KANDIDATMATCH_API
           value: https://aimatch.intern.nav.no
-        - name: KANDIDATSOK_ES_URL
-          value: https://opensearch-toi-kandidat-nav-prod.aivencloud.com:26482

--- a/deploy/nais-prod.yaml
+++ b/deploy/nais-prod.yaml
@@ -25,9 +25,6 @@ spec:
                     - NAVident
         sidecar:
             enabled: true
-    openSearch:
-      access: read
-      instance: kandidat
     accessPolicy:
       outbound:
         external:

--- a/deploy/nais-prod.yaml
+++ b/deploy/nais-prod.yaml
@@ -25,6 +25,9 @@ spec:
                     - NAVident
         sidecar:
             enabled: true
+    openSearch:
+      access: read
+      instance: rekrutteringsbistand-kandidat
     accessPolicy:
       outbound:
         external:
@@ -52,3 +55,5 @@ spec:
           value: https://toi-synlighetsmotor.intern.nav.no
         - name: KANDIDATMATCH_API
           value: https://aimatch.intern.nav.no
+        - name: KANDIDATSOK_ES_URL
+          value: https://opensearch-toi-kandidat-nav-prod.aivencloud.com:26482

--- a/server/src/azureAd.ts
+++ b/server/src/azureAd.ts
@@ -1,4 +1,4 @@
-import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
 import { FlattenedJWSInput, GetKeyFunction, JWSHeaderParameters } from 'jose/dist/types/types';
 import { Issuer, Client } from 'openid-client';
 import { logger } from './server';
@@ -8,6 +8,8 @@ const clientId = process.env.AZURE_APP_CLIENT_ID;
 
 let azureAdIssuer: Issuer<Client>;
 let remoteJWKSet: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput>;
+
+export const navIdentClaim = 'NAVident';
 
 export const initializeAzureAd = async () => {
     try {
@@ -43,4 +45,9 @@ export const tokenIsValid = async (token: string) => {
         logger.error('Noe galt skjedde under validering av token:', e);
         return false;
     }
+};
+
+export const hentNavIdent = (token: string) => {
+    const claims = decodeJwt(token);
+    return String(claims[navIdentClaim]) || '';
 };

--- a/server/src/featureToggle.ts
+++ b/server/src/featureToggle.ts
@@ -1,13 +1,12 @@
 import { Request, RequestHandler } from 'express';
 import { decodeJwt } from 'jose';
+import { hentNavIdent, navIdentClaim } from './azureAd';
 import { retrieveToken } from './middlewares';
 import { logger } from './server';
 
 const autoriserteBrukereForKandidatmatch = (
     process.env.KANDIDATMATCH_AUTORISERTE_BRUKERE || ''
 ).split(',');
-
-const navIdentClaim = 'NAVident';
 
 export const validerAtBrukerErAutorisertForKandidatmatch: RequestHandler = (req, res, next) => {
     const { autorisert, navIdent } = erAutorisertForKandidatmatch(req);
@@ -31,8 +30,7 @@ const erAutorisertForKandidatmatch = (
     navIdent: string;
 } => {
     const brukerensAccessToken = retrieveToken(req.headers);
-    const claims = decodeJwt(brukerensAccessToken);
-    const navIdent = String(claims[navIdentClaim]) || '';
+    const navIdent = hentNavIdent(brukerensAccessToken);
 
     return {
         autorisert: autoriserteBrukereForKandidatmatch.includes(navIdent),

--- a/server/src/featureToggle.ts
+++ b/server/src/featureToggle.ts
@@ -1,6 +1,6 @@
-import { Request } from 'express';
+import { Request, RequestHandler } from 'express';
 import { decodeJwt } from 'jose';
-import { Middleware, retrieveToken } from './middlewares';
+import { retrieveToken } from './middlewares';
 import { logger } from './server';
 
 const autoriserteBrukereForKandidatmatch = (
@@ -9,7 +9,7 @@ const autoriserteBrukereForKandidatmatch = (
 
 const navIdentClaim = 'NAVident';
 
-export const validerAtBrukerErAutorisertForKandidatmatch: Middleware = (req, res, next) => {
+export const validerAtBrukerErAutorisertForKandidatmatch: RequestHandler = (req, res, next) => {
     const { autorisert, navIdent } = erAutorisertForKandidatmatch(req);
 
     if (autorisert) {
@@ -20,7 +20,7 @@ export const validerAtBrukerErAutorisertForKandidatmatch: Middleware = (req, res
     }
 };
 
-export const responderOmBrukerErAutorisertForKandidatmatch: Middleware = (req, res) => {
+export const responderOmBrukerErAutorisertForKandidatmatch: RequestHandler = (req, res) => {
     res.status(200).json(erAutorisertForKandidatmatch(req).autorisert);
 };
 

--- a/server/src/kandidatsøk.ts
+++ b/server/src/kandidatsøk.ts
@@ -1,4 +1,41 @@
 import { RequestHandler } from 'express';
+import { hentNavIdent } from './azureAd';
+import { AdGruppe, hentBrukerensAdGrupper } from './microsoftGraphApi';
+import { retrieveToken } from './middlewares';
+import { logger } from './server';
+
+const adGrupperMedTilgangTilKandidatsøket = [
+    AdGruppe.ModiaGenerellTilgang,
+    AdGruppe.ModiaOppfølging,
+];
+
+export const harTilgangTilKandidatsøk: RequestHandler = async (request, response, next) => {
+    const brukerensAccessToken = retrieveToken(request.headers);
+    const navIdent = hentNavIdent(brukerensAccessToken);
+
+    try {
+        const brukerensAdGrupper = await hentBrukerensAdGrupper(brukerensAccessToken);
+        const harTilgang = brukerensAdGrupper.some((adGruppeBrukerErMedlemAv) =>
+            adGrupperMedTilgangTilKandidatsøket.includes(adGruppeBrukerErMedlemAv)
+        );
+
+        if (harTilgang) {
+            logger.info(`Bruker ${navIdent} fikk tilgang til kandidatsøket`);
+
+            next();
+        } else {
+            logger.info(
+                `Bruker ${navIdent} har ikke tilgang til kandidatsøket.\nKandidatsøket krever en av følgened AD-grupper: ${adGrupperMedTilgangTilKandidatsøket}\nBrukeren har følgende AD-grupper: ${brukerensAdGrupper}`
+            );
+
+            response.status(403).send('Brukeren har ikke tilgang til kandidatsøket');
+        }
+    } catch (e) {
+        const feilmelding = 'Klarte ikke å sjekke brukerens tilgang til kandidatsøket:';
+        logger.error(feilmelding + ': ' + e);
+        response.status(500).send(feilmelding);
+    }
+};
 
 export const leggTilAuthorizationForKandidatsøkEs =
     (brukernavn: string, passord: string): RequestHandler =>

--- a/server/src/kandidatsøk.ts
+++ b/server/src/kandidatsøk.ts
@@ -1,0 +1,10 @@
+import { Middleware } from './middlewares';
+
+export const leggTilAuthorizationForKandidatsøkEs =
+    (brukernavn: string, passord: string): Middleware =>
+    (_, req, next) => {
+        const encodedAuth = Buffer.from(`${brukernavn}:${passord}`).toString('base64');
+        req.setHeader('Authorization', `Basic ${encodedAuth}`);
+
+        next();
+    };

--- a/server/src/kandidatsøk.ts
+++ b/server/src/kandidatsøk.ts
@@ -7,7 +7,7 @@ import { logger } from './server';
 const adGrupperMedTilgangTilKandidatsøket = [
     AdGruppe.ModiaGenerellTilgang,
     AdGruppe.ModiaOppfølging,
-];
+].map((a) => a.toLowerCase());
 
 export const harTilgangTilKandidatsøk: RequestHandler = async (request, response, next) => {
     const brukerensAccessToken = retrieveToken(request.headers);
@@ -16,7 +16,9 @@ export const harTilgangTilKandidatsøk: RequestHandler = async (request, respons
     try {
         const brukerensAdGrupper = await hentBrukerensAdGrupper(brukerensAccessToken);
         const harTilgang = brukerensAdGrupper.some((adGruppeBrukerErMedlemAv) =>
-            adGrupperMedTilgangTilKandidatsøket.includes(adGruppeBrukerErMedlemAv)
+            adGrupperMedTilgangTilKandidatsøket.includes(
+                adGruppeBrukerErMedlemAv.toLocaleLowerCase()
+            )
         );
 
         if (harTilgang) {

--- a/server/src/kandidatsøk.ts
+++ b/server/src/kandidatsøk.ts
@@ -2,9 +2,9 @@ import { RequestHandler } from 'express';
 
 export const leggTilAuthorizationForKandidatsøkEs =
     (brukernavn: string, passord: string): RequestHandler =>
-    (_, req, next) => {
+    (request, _, next) => {
         const encodedAuth = Buffer.from(`${brukernavn}:${passord}`).toString('base64');
-        req.setHeader('Authorization', `Basic ${encodedAuth}`);
+        request.headers.authorization = `Basic ${encodedAuth}`;
 
         next();
     };

--- a/server/src/kandidatsøk.ts
+++ b/server/src/kandidatsøk.ts
@@ -30,7 +30,12 @@ export const harTilgangTilKandidatsøk: RequestHandler = async (request, respons
                 `Bruker ${navIdent} har ikke tilgang til kandidatsøket.\nKandidatsøket krever en av følgened AD-grupper: ${adGrupperMedTilgangTilKandidatsøket}\nBrukeren har følgende AD-grupper: ${brukerensAdGrupper}`
             );
 
-            response.status(403).send('Brukeren har ikke tilgang til kandidatsøket');
+            response
+                .status(403)
+                .send(
+                    'Du har ikke tilgang til kandidatsøket fordi det krever én av følgende AD-grupper: ' +
+                        adGrupperMedTilgangTilKandidatsøket
+                );
         }
     } catch (e) {
         const feilmelding = 'Klarte ikke å sjekke brukerens tilgang til kandidatsøket:';

--- a/server/src/kandidatsøk.ts
+++ b/server/src/kandidatsøk.ts
@@ -1,7 +1,7 @@
-import { Middleware } from './middlewares';
+import { RequestHandler } from 'express';
 
 export const leggTilAuthorizationForKandidatsøkEs =
-    (brukernavn: string, passord: string): Middleware =>
+    (brukernavn: string, passord: string): RequestHandler =>
     (_, req, next) => {
         const encodedAuth = Buffer.from(`${brukernavn}:${passord}`).toString('base64');
         req.setHeader('Authorization', `Basic ${encodedAuth}`);

--- a/server/src/microsoftGraphApi.ts
+++ b/server/src/microsoftGraphApi.ts
@@ -1,0 +1,38 @@
+import fetch from 'node-fetch';
+import { hentOnBehalfOfToken } from './onBehalfOfToken';
+import { logger } from './server';
+
+const apiScope = 'https://graph.microsoft.com/.default';
+const memberOfApiUrl = ' https://graph.microsoft.com/v1.0/me/memberOf';
+
+export enum AdGruppe {
+    ModiaGenerellTilgang = '0000-GA-BD06_ModiaGenerellTilgang',
+    ModiaOppfølging = '0000-GA-Modia-Oppfolging',
+}
+
+type Membership = {
+    displayName: AdGruppe;
+};
+
+type MemberOfResponse = {
+    value: Membership[];
+};
+
+export const hentBrukerensAdGrupper = async (accessToken: string): Promise<AdGruppe[]> => {
+    try {
+        const oboToken = await hentOnBehalfOfToken(accessToken, apiScope);
+        const adGrupperResponse = await fetch(memberOfApiUrl, {
+            headers: {
+                Authorization: `Bearer ${oboToken.access_token}`,
+            },
+        });
+
+        const adGrupper: MemberOfResponse = await adGrupperResponse.json();
+        return adGrupper.value.map((gruppe) => gruppe.displayName);
+    } catch (error) {
+        const feilmelding = 'Feil under henting av brukers AD-grupper';
+
+        logger.error(feilmelding + ': ' + error);
+        throw new Error(feilmelding);
+    }
+};

--- a/server/src/middlewares.ts
+++ b/server/src/middlewares.ts
@@ -13,7 +13,7 @@ export const redirectIfUnauthorized: RequestHandler = async (req, res, next) => 
     }
 };
 
-export const respondUnauthorizedIfUnauthorized: RequestHandler = async (req, res, next) => {
+export const respondUnauthorizedIfNotLoggedIn: RequestHandler = async (req, res, next) => {
     if (await userIsLoggedIn(req)) {
         next();
     } else {

--- a/server/src/middlewares.ts
+++ b/server/src/middlewares.ts
@@ -1,13 +1,11 @@
-import { NextFunction, Request, Response } from 'express';
+import { NextFunction, Request, RequestHandler, Response } from 'express';
 import { IncomingHttpHeaders } from 'http';
 import { tokenIsValid } from './azureAd';
 import { hentOnBehalfOfToken } from './onBehalfOfToken';
 
-export type Middleware = (req: Request, res: Response, next: NextFunction) => void;
-
 export const cluster = process.env.NAIS_CLUSTER_NAME;
 
-export const redirectIfUnauthorized: Middleware = async (req, res, next) => {
+export const redirectIfUnauthorized: RequestHandler = async (req, res, next) => {
     if (await userIsLoggedIn(req)) {
         next();
     } else {
@@ -15,7 +13,7 @@ export const redirectIfUnauthorized: Middleware = async (req, res, next) => {
     }
 };
 
-export const respondUnauthorizedIfUnauthorized: Middleware = async (req, res, next) => {
+export const respondUnauthorizedIfUnauthorized: RequestHandler = async (req, res, next) => {
     if (await userIsLoggedIn(req)) {
         next();
     } else {
@@ -23,7 +21,7 @@ export const respondUnauthorizedIfUnauthorized: Middleware = async (req, res, ne
     }
 };
 
-export const opprettCookieFraAuthorizationHeader: Middleware = (req, res, next) => {
+export const opprettCookieFraAuthorizationHeader: RequestHandler = (req, res, next) => {
     const token = retrieveToken(req.headers);
 
     if (token) {
@@ -68,6 +66,6 @@ async function userIsLoggedIn(req: Request): Promise<boolean> {
     return token && (await tokenIsValid(token));
 }
 
-export const tomMiddleware: Middleware = (_, __, next) => {
+export const tomMiddleware: RequestHandler = (_, __, next) => {
     next();
 };

--- a/server/src/proxy.ts
+++ b/server/src/proxy.ts
@@ -1,10 +1,6 @@
 import { ClientRequest } from 'http';
 import { createProxyMiddleware } from 'http-proxy-middleware';
-import {
-    respondUnauthorizedIfUnauthorized,
-    tomMiddleware,
-    setOnBehalfOfToken,
-} from './middlewares';
+import { respondUnauthorizedIfNotLoggedIn, tomMiddleware, setOnBehalfOfToken } from './middlewares';
 import { leggTilAuthorizationForKandidatsøkEs } from './kandidatsøk';
 import { app, logger } from './server';
 import { RequestHandler } from 'express';
@@ -47,7 +43,7 @@ export const proxyMedOboToken = (
 ) => {
     app.use(
         path,
-        respondUnauthorizedIfUnauthorized,
+        respondUnauthorizedIfNotLoggedIn,
         customMiddleware ? customMiddleware : tomMiddleware,
         setOnBehalfOfToken(apiScope),
         setupProxy(path, apiUrl)
@@ -62,7 +58,7 @@ export const proxyTilKandidatsøkEs = (
 ) => {
     app.use(
         path,
-        respondUnauthorizedIfUnauthorized,
+        respondUnauthorizedIfNotLoggedIn,
         leggTilAuthorizationForKandidatsøkEs(brukernavn, passord),
         setupProxy(path, proxyUrl)
     );

--- a/server/src/proxy.ts
+++ b/server/src/proxy.ts
@@ -1,13 +1,13 @@
 import { ClientRequest } from 'http';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import {
-    Middleware,
     respondUnauthorizedIfUnauthorized,
     tomMiddleware,
     setOnBehalfOfToken,
 } from './middlewares';
 import { leggTilAuthorizationForKandidatsøkEs } from './kandidatsøk';
 import { app, logger } from './server';
+import { RequestHandler } from 'express';
 
 const removeIssoIdToken = (request: ClientRequest) => {
     const requestCookies = request.getHeader('Cookie')?.toString();
@@ -21,7 +21,11 @@ const removeIssoIdToken = (request: ClientRequest) => {
 };
 
 // Krever ekstra miljøvariabler, se nais.yaml
-export const setupProxy = (fraPath: string, tilTarget: string, fjernIssoIdToken = true) =>
+export const setupProxy = (
+    fraPath: string,
+    tilTarget: string,
+    fjernIssoIdToken = true
+): RequestHandler =>
     createProxyMiddleware(fraPath, {
         target: tilTarget,
         changeOrigin: true,
@@ -39,7 +43,7 @@ export const proxyMedOboToken = (
     path: string,
     apiUrl: string,
     apiScope: string,
-    customMiddleware?: Middleware
+    customMiddleware?: RequestHandler
 ) => {
     app.use(
         path,

--- a/server/src/proxy.ts
+++ b/server/src/proxy.ts
@@ -1,7 +1,7 @@
 import { ClientRequest } from 'http';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { respondUnauthorizedIfNotLoggedIn, tomMiddleware, setOnBehalfOfToken } from './middlewares';
-import { leggTilAuthorizationForKandidatsøkEs } from './kandidatsøk';
+import { harTilgangTilKandidatsøk, leggTilAuthorizationForKandidatsøkEs } from './kandidatsøk';
 import { app, logger } from './server';
 import { RequestHandler } from 'express';
 
@@ -59,7 +59,8 @@ export const proxyTilKandidatsøkEs = (
     app.use(
         path,
         respondUnauthorizedIfNotLoggedIn,
+        harTilgangTilKandidatsøk,
         leggTilAuthorizationForKandidatsøkEs(brukernavn, passord),
-        setupProxy(path, proxyUrl)
+        setupProxy(path, proxyUrl + '/veilederkandidat_current/_search')
     );
 };

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -87,7 +87,7 @@ const startServer = () => {
     );
 
     proxyTilKandidatsøkEs(
-        '/kandidatsok-es',
+        '/kandidatsok-proxy',
         OPEN_SEARCH_URI,
         OPEN_SEARCH_USERNAME,
         OPEN_SEARCH_PASSWORD

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -42,7 +42,7 @@ const scopes = {
     kandidatmatch: `api://${cluster}.team-ai.team-ai-match/.default`,
 };
 
-const proxyWithAuth = (
+const proxyWithOboToken = (
     path: string,
     apiUrl: string,
     apiScope: string,
@@ -57,6 +57,10 @@ const proxyWithAuth = (
     );
 };
 
+const proxyTilKandidatsøkEs = (path: string, proxyUrl: string) => {
+    app.use(path, respondUnauthorizedIfUnauthorized, setupProxy(path, proxyUrl));
+};
+
 const {
     STILLING_API_URL,
     STATISTIKK_API_URL,
@@ -66,6 +70,7 @@ const {
     FORESPORSEL_OM_DELING_AV_CV_API,
     SYNLIGHETSMOTOR_API,
     KANDIDATMATCH_API,
+    KANDIDATSOK_ES_URL,
 } = process.env;
 
 const startServer = () => {
@@ -83,23 +88,25 @@ const startServer = () => {
         responderOmBrukerErAutorisertForKandidatmatch
     );
 
-    proxyWithAuth('/statistikk-api', STATISTIKK_API_URL, scopes.statistikk);
-    proxyWithAuth('/stillingssok-proxy', STILLINGSSOK_PROXY_URL, scopes.stillingssøk);
-    proxyWithAuth('/stilling-api', STILLING_API_URL, scopes.stilling);
-    proxyWithAuth('/kandidat-api', KANDIDAT_API_URL, scopes.kandidat);
-    proxyWithAuth('/sms-api', SMS_API, scopes.sms);
-    proxyWithAuth(
+    proxyWithOboToken('/statistikk-api', STATISTIKK_API_URL, scopes.statistikk);
+    proxyWithOboToken('/stillingssok-proxy', STILLINGSSOK_PROXY_URL, scopes.stillingssøk);
+    proxyWithOboToken('/stilling-api', STILLING_API_URL, scopes.stilling);
+    proxyWithOboToken('/kandidat-api', KANDIDAT_API_URL, scopes.kandidat);
+    proxyWithOboToken('/sms-api', SMS_API, scopes.sms);
+    proxyWithOboToken(
         '/foresporsel-om-deling-av-cv-api',
         FORESPORSEL_OM_DELING_AV_CV_API,
         scopes.forespørselOmDelingAvCv
     );
-    proxyWithAuth('/synlighet-api', SYNLIGHETSMOTOR_API, scopes.synlighetsmotor);
-    proxyWithAuth(
+    proxyWithOboToken('/synlighet-api', SYNLIGHETSMOTOR_API, scopes.synlighetsmotor);
+    proxyWithOboToken(
         '/kandidatmatch-api',
         KANDIDATMATCH_API,
         scopes.kandidatmatch,
         validerAtBrukerErAutorisertForKandidatmatch
     );
+
+    proxyTilKandidatsøkEs('/kandidatsok-es', KANDIDATSOK_ES_URL);
 
     app.get(
         pathsForServingApp,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,7 +7,7 @@ import { initializeAzureAd } from './azureAd';
 import {
     opprettCookieFraAuthorizationHeader,
     redirectIfUnauthorized,
-    respondUnauthorizedIfUnauthorized,
+    respondUnauthorizedIfNotLoggedIn,
 } from './middlewares';
 import {
     responderOmBrukerErAutorisertForKandidatmatch,
@@ -64,7 +64,7 @@ const startServer = () => {
 
     app.get(
         '/feature-toggle/kandidatmatch',
-        respondUnauthorizedIfUnauthorized,
+        respondUnauthorizedIfNotLoggedIn,
         responderOmBrukerErAutorisertForKandidatmatch
     );
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -48,11 +48,9 @@ const {
     FORESPORSEL_OM_DELING_AV_CV_API,
     SYNLIGHETSMOTOR_API,
     KANDIDATMATCH_API,
-    KANDIDATSOK_ES_URL,
-
-    // TODO: Bruk de faktiske miljøvariablene fra Nais
-    KANDIDATSOK_ES_USERNAME,
-    KANDIDATSOK_ES_PASSWORD,
+    OPEN_SEARCH_URI,
+    OPEN_SEARCH_USERNAME,
+    OPEN_SEARCH_PASSWORD,
 } = process.env;
 
 const startServer = () => {
@@ -90,9 +88,9 @@ const startServer = () => {
 
     proxyTilKandidatsøkEs(
         '/kandidatsok-es',
-        KANDIDATSOK_ES_URL,
-        KANDIDATSOK_ES_USERNAME,
-        KANDIDATSOK_ES_PASSWORD
+        OPEN_SEARCH_URI,
+        OPEN_SEARCH_USERNAME,
+        OPEN_SEARCH_PASSWORD
     );
 
     app.get(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,13 @@ import { Switch, Route, useLocation, useHistory } from 'react-router-dom';
 
 import Navigeringsmeny from './navigeringsmeny/Navigeringsmeny';
 import Modiadekoratør from './modia/Modiadekoratør';
-import { Kandidat, Statistikk, Stilling, Stillingssøk } from './microfrontends/microfrontends';
+import {
+    Kandidat,
+    Kandidatsøk,
+    Statistikk,
+    Stilling,
+    Stillingssøk,
+} from './microfrontends/microfrontends';
 import {
     AmplitudeEvent,
     sendEvent,
@@ -11,6 +17,7 @@ import {
     setNavKontorForAmplitude,
 } from './amplitude';
 import { generaliserPath } from './utils/path';
+import { erIkkeProd } from './miljø';
 
 const App: FunctionComponent = () => {
     const history = useHistory();
@@ -54,9 +61,14 @@ const App: FunctionComponent = () => {
                     <Route path="/stillingssok">
                         <Stillingssøk navKontor={navKontor} history={history} />
                     </Route>
-                    <Route path={['/kandidater', '/kandidatsok', '/prototype']}>
+                    <Route path={['/kandidater', '/prototype']}>
                         <Kandidat navKontor={navKontor} history={history} />
                     </Route>
+                    {erIkkeProd() && (
+                        <Route path="/kandidatsok">
+                            <Kandidatsøk navKontor={navKontor} history={history} />
+                        </Route>
+                    )}
                     <Route exact path="/">
                         <Statistikk navKontor={navKontor} history={history} />
                     </Route>

--- a/src/microfrontends/microfrontends.tsx
+++ b/src/microfrontends/microfrontends.tsx
@@ -24,6 +24,13 @@ const kandidatConfig = {
     loader: <LasterInn />,
 };
 
+const kandidatsøkConfig = {
+    appName: 'rekrutteringsbistand-kandidatsok',
+    appBaseUrl: '/rekrutteringsbistand-kandidatsok',
+    assetManifestParser: assetManifestParser(),
+    loader: <LasterInn />,
+};
+
 const statistikkConfig = {
     appName: 'rekrutteringsbistand-statistikk',
     appBaseUrl: '/rekrutteringsbistand-statistikk',
@@ -49,3 +56,4 @@ export const Statistikk = AsyncNavspa.importer<FellesMicrofrontendProps>(statist
 export const Stillingssøk = AsyncNavspa.importer<FellesMicrofrontendProps>(stillingssøkConfig);
 export const Stilling = AsyncNavspa.importer<FellesMicrofrontendProps>(stillingConfig);
 export const Kandidat = AsyncNavspa.importer<FellesMicrofrontendProps>(kandidatConfig);
+export const Kandidatsøk = AsyncNavspa.importer<FellesMicrofrontendProps>(kandidatsøkConfig);

--- a/src/miljø.ts
+++ b/src/miljø.ts
@@ -17,6 +17,5 @@ export const getMiljø = (): string => {
 };
 
 export const erIkkeProd = (): boolean => {
-    const pathname = window.location.hostname;
-    return pathname.includes('dev.intern.nav.no');
+    return getMiljø() !== Miljø.ProdGcp;
 };

--- a/src/navigeringsmeny/Navigeringsmeny.tsx
+++ b/src/navigeringsmeny/Navigeringsmeny.tsx
@@ -5,6 +5,7 @@ import Tab, { TabConfig } from './Tab';
 import Forsidelenke from './Forsidelenke';
 import Nyheter from '../nyheter/Nyheter';
 import css from './Navigeringsmeny.module.css';
+import { erIkkeProd } from '../miljø';
 
 const appPrefiks = '';
 
@@ -27,6 +28,13 @@ const tabs: TabConfig[] = [
         path: '/kandidater/lister',
     },
 ];
+
+if (erIkkeProd()) {
+    tabs.push({
+        tittel: 'Nytt kandidatsøk',
+        path: '/kandidatsok',
+    });
+}
 
 const Navigeringsmeny: FunctionComponent = () => {
     const { pathname }: any = useLocation();

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -15,4 +15,5 @@ module.exports = (app) => {
     setupProxy('/rekrutteringsbistand-stilling', 'http://localhost:3002');
     setupProxy('/rekrutteringsbistand-kandidat', 'http://localhost:3003');
     setupProxy('/rekrutteringsbistand-stillingssok', 'http://localhost:3004');
+    setupProxy('/rekrutteringsbistand-kandidatsok', 'http://localhost:3005');
 };


### PR DESCRIPTION
Må ikke merges før følgende er avklart:

- Nå er det slik at Node-appen sjekker om veileder er logget inn, før kallet kan gå direkte videre til ElasticSearch med en Basic Authorization-header satt av proxyen.
- Det gjøres ikke noe sjekk utover å validere at tokenet er gyldig
- Er det slik at dette holder? Skal man ha lov til å utøve alle slags søk mot ElasticSearch, så lenge man har et gyldig token?
- Bør undersøke ytterligere i kandidat-api for å sørge for at det ikke kreves ytterligere sikkerhetsmekanismer

Etter undersøkt litt:

- Trenger vi å bruke ABAC?
- Hvis ja, kan vi kalle ABAC fra Node?