### PR TITLE
Endrer url til å kun ta med AD-grupper som begynner på 0000

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
     deploy-til-dev:
         name: Deploy til dev-gcp
         needs: bygg-og-push-docker-image
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/modiacontextholder-proxy'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/endre-url'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3

--- a/server/src/kandidatsøk/kandidatsøk.ts
+++ b/server/src/kandidatsøk/kandidatsøk.ts
@@ -38,7 +38,7 @@ export const harTilgangTilKandidatsøk: RequestHandler = async (request, respons
 
     try {
         const { harTilgang, brukerensAdGrupper } = await sjekkTilgang(brukerensAccessToken);
-        const forklaring = `Kandidatsøket krever medlemskap i en av følgened AD-grupper: ${adGrupperMedTilgangTilKandidatsøket}.`;
+        const forklaring = `Kandidatsøket krever medlemskap i en av følgende AD-grupper: ${adGrupperMedTilgangTilKandidatsøket}.`;
 
         if (harTilgang) {
             logger.info(`Bruker ${navIdent} fikk tilgang til kandidatsøket.\n${forklaring}`);

--- a/server/src/microsoftGraphApi.ts
+++ b/server/src/microsoftGraphApi.ts
@@ -2,8 +2,8 @@ import fetch from 'node-fetch';
 import { hentOnBehalfOfToken } from './onBehalfOfToken';
 import { logger } from './logger';
 
-const apiScope = 'https://graph.microsoft.com/.default';
-const memberOfApiUrl = ' https://graph.microsoft.com/v1.0/me/memberOf';
+const apiScope = "https://graph.microsoft.com/.default";
+const memberOfApiUrl = "https://graph.microsoft.com/v1.0/me/memberOf?$filter=startswith(displayName, '0000-GA')";
 
 export enum AdGruppe {
     ModiaGenerellTilgang = '0000-GA-BD06_ModiaGenerellTilgang',

--- a/server/src/microsoftGraphApi.ts
+++ b/server/src/microsoftGraphApi.ts
@@ -3,7 +3,7 @@ import { hentOnBehalfOfToken } from './onBehalfOfToken';
 import { logger } from './logger';
 
 const apiScope = "https://graph.microsoft.com/.default";
-const memberOfApiUrl = "https://graph.microsoft.com/v1.0/me/memberOf/microsoft.graph.group?$filter=startswith(displayName, '0000-GA')";
+const memberOfApiUrl = "https://graph.microsoft.com/v1.0/me/memberOf/?$count=true&$orderby=displayName&$filter=startswith(displayName, '0000-GA')";
 
 export enum AdGruppe {
     ModiaGenerellTilgang = '0000-GA-BD06_ModiaGenerellTilgang',
@@ -24,6 +24,7 @@ export const hentBrukerensAdGrupper = async (accessToken: string): Promise<AdGru
         const adGrupperResponse = await fetch(memberOfApiUrl, {
             headers: {
                 Authorization: `Bearer ${oboToken.access_token}`,
+                ConsistencyLevel: "eventual"
             },
         });
 

--- a/server/src/microsoftGraphApi.ts
+++ b/server/src/microsoftGraphApi.ts
@@ -3,7 +3,7 @@ import { hentOnBehalfOfToken } from './onBehalfOfToken';
 import { logger } from './logger';
 
 const apiScope = "https://graph.microsoft.com/.default";
-const memberOfApiUrl = "https://graph.microsoft.com/v1.0/me/memberOf?$filter=startswith(displayName, '0000-GA')";
+const memberOfApiUrl = "https://graph.microsoft.com/v1.0/me/memberOf/microsoft.graph.group?$filter=startswith(displayName, '0000-GA')";
 
 export enum AdGruppe {
     ModiaGenerellTilgang = '0000-GA-BD06_ModiaGenerellTilgang',


### PR DESCRIPTION
Hvis en person har for mange AD-grupper så får vi kun med de 100 første med url'en vi bruker i dag. Det vil innebære at vi får feil på at noen har tilgang fordi AD-gruppen ikke blir med.
Microsoft sitt memberof endepunkt har paging som returnerer max 100 AD-grupper